### PR TITLE
Add importer conversion to scene library

### DIFF
--- a/cmake/impeller_scene.cmake
+++ b/cmake/impeller_scene.cmake
@@ -25,7 +25,7 @@ target_include_directories(scene_shaders_lib
         $<BUILD_INTERFACE:${FLUTTER_INCLUDE_DIR}> # For includes starting with "flutter/"
         $<BUILD_INTERFACE:${FLUTTER_ENGINE_DIR}>) # For includes starting with "impeller/"
 
-file(GLOB SCENE_SOURCES ${IMPELLER_SCENE_DIR}/*.cc ${IMPELLER_SCENE_DIR}/animation/*.cc)
+file(GLOB SCENE_SOURCES ${IMPELLER_SCENE_DIR}/*.cc ${IMPELLER_SCENE_DIR}/animation/*.cc ${IMPELLER_SCENE_DIR}/importer/conversions.cc)
 list(FILTER SCENE_SOURCES EXCLUDE REGEX ".*_unittests?\\.cc$")
 
 add_library(impeller_scene STATIC ${SCENE_SOURCES})


### PR DESCRIPTION
This PR proposes changes from the current `impeller-cmake` branch `user/ralph/scene-symbols`. Didn't know what else to do but bring the PR forward from a fork.

I'm working with @iamralpht who did the original change. This adds impeller vector/matrix conversion code which is lacking in the current importer build.

I've tested this against our local build, but am unsure of the workflows to test this repo independently. Do you have anything to suggest there?

With this we should be synced with this repo `main` branch.

I've done some work adding basic text support (`stb` text backend  replacing the current text `noop` module ) that I hope to bring forward shortly.