### PR TITLE
Generate `entity_shaders` as Part of `impeller_entity` Library

### DIFF
--- a/cmake/impeller_entity.cmake
+++ b/cmake/impeller_entity.cmake
@@ -71,6 +71,7 @@ add_gles_shader_library(
     OUTPUT_DIR ${IMPELLER_GENERATED_DIR}/impeller/entity)
 
 add_library(entity_shaders_lib STATIC
+    "${IMPELLER_GENERATED_DIR}/impeller/entity/gles/entity_shaders_gles.cc"
     "${IMPELLER_GENERATED_DIR}/impeller/entity/advanced_blend.vert.cc"
     "${IMPELLER_GENERATED_DIR}/impeller/entity/advanced_blend_color.frag.cc"
     "${IMPELLER_GENERATED_DIR}/impeller/entity/advanced_blend_colorburn.frag.cc"


### PR DESCRIPTION
# Bug Description

I'm unsure if this is the right approach, but when updating `impeller-cmake` to the latest I found I was missing a generated shader header file: `./out/build/ninja-debug/third_party/impeller-cmake/generated/impeller/entity/gles/entity_shaders_gles.h`.

The lack of this file blocked me from initializing a usable rendering pipeline (at least with our current Impeller context creation code).

This fix allows that file to be generated again, and I don't yet see any side effects. Again I'm unsure if this is the general approach you have in mind for this repo, so I'm open to discussing alternate approaches to solving this.

Tested using the `impeller-cmake-example` repository on linux. That does not exercise functionality provided by `entity_shaders` but at least does not break.

